### PR TITLE
Add support for password file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ gokey -p super-secret-master-password -r example.com
 ###### options
 
   - `-o <output path>` - by default **gokey** outputs generated data to `stdout`
-  - `-p <master password>` - master password which will be used to generate other passwords/keys or to encrypt seed file (see [Modes of operation](#modes-of-operation) below, if not provided, **gokey** will ask for it interactively)
+  - `-P </path/to/password>` - path to master password file which will be used to generate other passwords/keys or to encrypt seed file (see [Modes of operation](#modes-of-operation) below, if no master password or master password file is provided, **gokey** will ask for it interactively)
+  - `-p <master password>` - master password which will be used to generate other passwords/keys or to encrypt seed file (see [Modes of operation](#modes-of-operation) below, if no master password or master password file is provided, **gokey** will ask for it interactively)
   - `-r <password/key realm>` - any string which identifies requested password/key, most likely key usage or resource URL
   - `-s <path to seed file>` - needed, if you want to use seed file instead of master password as an entropy source (see [Modes of operation](#modes-of-operation) below); can be generated with `-t seed` flag as described below
   - `-skip <number of bytes>` - number of bytes to skip when reading seed file

--- a/cmd/gokey/main.go
+++ b/cmd/gokey/main.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/cloudflare/gokey"
@@ -16,13 +17,14 @@ import (
 )
 
 var (
-	pass, keyType, seedPath, realm, output string
-	unsafe                                 bool
-	seedSkipCount                          int
+	pass, passFile, keyType, seedPath, realm, output string
+	unsafe                                           bool
+	seedSkipCount                                    int
 )
 
 func init() {
 	flag.StringVar(&pass, "p", "", "master password (if not specified, will be asked interactively)")
+	flag.StringVar(&passFile, "P", "", "master password file (if not specified, will be asked interactively)")
 	flag.StringVar(&keyType, "t", "pass", "output type (can be pass, seed, raw, ec256, ec521, rsa2048, rsa4096, x25519, ed25519)")
 	flag.StringVar(&seedPath, "s", "", "path to master seed file (optional)")
 	flag.IntVar(&seedSkipCount, "skip", 0, "number of bytes to skip from master seed file (default 0)")
@@ -102,6 +104,14 @@ func main() {
 	flag.Parse()
 
 	var err error
+	if pass == "" && passFile != "" {
+		var content []byte
+		content, err = ioutil.ReadFile(passFile)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		pass = strings.TrimSpace(string(content[:]))
+	}
 	if pass == "" {
 		var passBytes []byte
 		var passBytesAgain []byte

--- a/gokey.1.md
+++ b/gokey.1.md
@@ -30,10 +30,16 @@ immediately anywhere.
 **-o** *output_path*
 :    by default **gokey** outputs generated data to *stdout*
 
+**-P** */path/to/password*
+:    path to master password file which will be used to generate other
+passwords/keys or to encrypt seed file (see *Modes of operation* below, if no
+master password or master password file is provided, **gokey** will ask for it
+interactively)
+
 **-p** *master_password*
 :    master password which will be used to generate other passwords/keys or to
-encrypt seed file (see *Modes of operation* below, if not provided, **gokey**
-will ask for it interactively)
+encrypt seed file (see *Modes of operation* below, if no master password or
+master password file is provided, **gokey** will ask for it interactively)
 
 **-r** *password/key_realm*
 :    any string which identifies requested password/key, most likely key usage


### PR DESCRIPTION
To avoid having the master password ending up in the shell history, add support for specifying a password file. (closes #12)