### PR TITLE
Run Travis CI with multiple Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: go
 
+go:
+  - "1.10.x"
+  - "1.x"
+  - master
+
 go_import_path: github.com/cloudflare/gokey


### PR DESCRIPTION
This is to give a better picture of TestGetKey test failure on Go >= 1.11 (to be reported in another issue).

Happy New Year!