### PR TITLE
Explicitly cast Stdin file descriptors to int for ssh/terminal invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: go
 
+os:
+  - linux
+  - windows
+
 go:
   - "1.10.x"
   - "1.x"
   - master
+
+# golang master is not available for Windows builds for some reason
+matrix:
+  exclude:
+    - os: windows
+      go: master
 
 go_import_path: github.com/cloudflare/gokey

--- a/cmd/gokey/main.go
+++ b/cmd/gokey/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/cloudflare/gokey"
 	"golang.org/x/crypto/ssh/terminal"
@@ -118,7 +117,7 @@ func main() {
 		for {
 			for len(passBytes) == 0 {
 				fmt.Print("Master password: ")
-				passBytes, err = terminal.ReadPassword(syscall.Stdin)
+				passBytes, err = terminal.ReadPassword(int(os.Stdin.Fd()))
 				if err != nil {
 					log.Fatalln(err)
 				}
@@ -130,7 +129,7 @@ func main() {
 			}
 
 			fmt.Print("Master password again: ")
-			passBytesAgain, err = terminal.ReadPassword(syscall.Stdin)
+			passBytesAgain, err = terminal.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
 				log.Fatalln(err)
 			}


### PR DESCRIPTION
On Windows, the file descriptors are syscall.Handle. Go can return them in
uintptr, but this is still not compatible with ssh/terminal. It should be safe
to convert them to int, because Windows implementation of ssh/terminal converts
them back to handles internally anyway.

Fixes #22 