### PR TITLE
Expose SeedSize constant

### DIFF
--- a/csprng.go
+++ b/csprng.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	keySeedLength = 256
+	SeedSize = 256
 )
 
 type devZero struct{}
@@ -60,7 +60,7 @@ func NewDRNGwithSeed(password, realm string, seed []byte) (io.Reader, error) {
 }
 
 func GenerateEncryptedKeySeed(password string) ([]byte, error) {
-	seed := make([]byte, keySeedLength)
+	seed := make([]byte, SeedSize)
 
 	_, err := rand.Read(seed)
 	if err != nil {


### PR DESCRIPTION
This pull request exposes the `SeedSize` constant, similar to [`crypto/ed25519.SeedSize`](https://pkg.go.dev/crypto/ed25519#pkg-constants) in the standard library. This constant will allow users to know in advance the minimum allowed length for the seed, instead of facing runtime errors like `slice bounds out of range [12:8]` when trying to use a shorter seed.