### PR TITLE
replaced deprecated package

### DIFF
--- a/cmd/gokey/main.go
+++ b/cmd/gokey/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/cloudflare/gokey"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 var (
@@ -125,7 +125,7 @@ func main() {
 		for {
 			for len(passBytes) == 0 {
 				fmt.Fprint(os.Stderr, "Master password: ")
-				passBytes, err = terminal.ReadPassword(int(os.Stdin.Fd()))
+				passBytes, err = term.ReadPassword(int(os.Stdin.Fd()))
 				if err != nil {
 					log.Fatalln(err)
 				}
@@ -137,7 +137,7 @@ func main() {
 			}
 
 			fmt.Fprint(os.Stderr, "Master password again: ")
-			passBytesAgain, err = terminal.ReadPassword(int(os.Stdin.Fd()))
+			passBytesAgain, err = term.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
 				log.Fatalln(err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/cloudflare/gokey
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+require (
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
+)


### PR DESCRIPTION
The package `golang.org/x/crypto/ssh/terminal` is deprecated and it has been moved to `golang.org/x/term`.

This change has been made to reflect that, the CLI was built and tested and it works as intended.

The version of crypto has also been bumped up so that the CLI will build and run on Macs. See: https://github.com/cloudflare/gokey/pull/40 (It would be ideal if PR#40 is merged first before merging this)

