### PR TITLE
Improvements to Github actions - added macOS,Windows + cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ ubuntu-latest, macos-latest , windows-latest ]
         go: [ '1.13', '1.17', '>=1.18' ]
-    name: Test go${{ matrix.go }}
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} - go${{ matrix.go }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
We run into issues like https://github.com/cloudflare/gokey/issues/45 where the CLI tool breaks for one particular OS and it is due to a bug down the dependency tree.

In order to avoid issues like this @jagger27 has made some good fixes like #43 and #40. In this PR I have

1. Added MacOs and Windows to ensure cross-platform compatibility (And to catch occurrences like #45).
2. ~~Set the pipeline to run weekly on Tuesdays to notify the maintainer about failures.~~
3. Trimmed the string 'Test' from the name of the build stage to improve readability(The name of the tests got too long). 

Tested extensively here on my fork https://github.com/IgnorantSapient/gokey/actions/runs/2659679942 

